### PR TITLE
Adding Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "chrisgoddard/acf-address-map-field",
-    "description": "Advanced Custom Fields plugin: Address/Map Field",
+    "description": "Full Address field with geo-coded map. Compatible ACF 4 & 5",
     "keywords": ["wordpress", "plugin"],
     "type": "wordpress-plugin",
     "homepage": "https://github.com/chrisgoddard/acf-address-map-field",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "chrisgoddard/acf-address-map-field",
+    "description": "Advanced Custom Fields plugin: Address/Map Field",
+    "keywords": ["wordpress", "plugin"],
+    "type": "wordpress-plugin",
+    "homepage": "https://github.com/chrisgoddard/acf-address-map-field",
+    "authors": [
+        {
+            "name": "Chris Goddard",
+            "homepage": "www.chrisgoddard.me"
+        }
+     ],
+    "license": "GPLv2 or later",
+    "require": {
+    "composer/installers": "v1.0.7"
+    }
+}


### PR DESCRIPTION
Would like to add basic composer support for this plugin. Composer is dependency manager. It is easy to use, all dependency are defined in a single place and consistent across team and servers. Having Composer support does not influence work of original plugin in any way.

For more info on Composer and Wordpress: https://roots.io/using-composer-with-wordpress/